### PR TITLE
Delete reverse floating IP records on FIP deletion

### DIFF
--- a/neutron/db/dns_db.py
+++ b/neutron/db/dns_db.py
@@ -187,6 +187,10 @@ class DNSDbMixin(object):
                 context, dns_data_db['published_dns_domain'],
                 dns_data_db['published_dns_name'],
                 [floatingip_data['floating_ip_address']])
+        else:
+            self._delete_floatingip_from_external_dns_service(
+                context, None, None,
+                [floatingip_data['floating_ip_address']])
 
     def _validate_floatingip_dns(self, dns_name, dns_domain):
         if dns_domain and not dns_name:
@@ -209,6 +213,9 @@ class DNSDbMixin(object):
 
     def _delete_floatingip_from_external_dns_service(self, context, dns_domain,
                                                      dns_name, records):
+        if not self.dns_driver:
+            return
+
         ips = [str(r) for r in records]
         try:
             self.dns_driver.delete_record_set(context, dns_domain, dns_name,


### PR DESCRIPTION
When floating ip is created without dns_name and dns_domain, ptr record
is created in desigate. After setting ptrdname on ptr record, new
reverse floating ip record is created within zone. After deletion of
floating ip the record still exist.
Fix this issue by trying to delete recordset within zone by admin_client
and allowed to see all projects. Keep the existing logic of floating ip
deletion with dns_domain and dns_name as it was.

Closes-Bug: #1746627